### PR TITLE
Fix redundancies

### DIFF
--- a/GameData/JetSoundsUpdated/Patches/Goliath.cfg
+++ b/GameData/JetSoundsUpdated/Patches/Goliath.cfg
@@ -68,8 +68,9 @@
 {
 	@EFFECTS
 	{		
-		flameout
+		%flameout
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -82,129 +83,13 @@
 	}
 }
 
-@PART[turboFanSize2]:NEEDS[RealPlume]:FOR[zzJetSounds]
+@PART[turboFanSize2]:AFTER[zzRealPlume]
 {
-    %EFFECTS
-    {
-        %Turbofan
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                
-                transformName = #$../../../PLUME[Turbofan]/transformName$
-                localRotation = #$../../../PLUME[Turbofan]/localRotation[0]$,$../../../PLUME[Turbofan]/localRotation[1]$,$../../../PLUME[Turbofan]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbofan]/plumePosition[0]$,$../../../PLUME[Turbofan]/plumePosition[1]$,$../../../PLUME[Turbofan]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbofan]/plumeScale$
-                energy        = #$../../../PLUME[Turbofan]/energy$
-                speed         = #$../../../PLUME[Turbofan]/speed$
-                emissionMult  = #$../../../PLUME[Turbofan]/emissionMult$
-                //
-                name = plume
-                modelName = RealPlume/MP_Nazari_FX/flamejet3
-                speed = 0.0 1.45
-                speed = 1.0 1.45
-                energy = 0.0 0.05
-                energy = 0.5 0.4
-                energy = 1.0 0.7
-                fixedEmissions = false
-                randConeEmit
-                {
-                  density = 1 0
-                  density = 0 0.5
-                }
-                energy
-                {
-                  density = 1 0.5
-                  density = 0 0.2
-                }
-                emission
-                {
-                  density = 1 1
-                  density = 0 0.5
-                  power = 0.0 0.0
-                  power = 0.42 0.0
-                  power = 0.54 1.55
-                  power = 1.0 1.78
-                }
-                speed
-                {
-                  density = 1 1.2
-                  density = 0 1.5
-                }
-            }
-        }
-        %Turbofan-Spool
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Turbofan]/transformName$
-                fixedScale    = #$../../../PLUME[Turbofan]/smokeScale$
-                localPosition = #$../../../PLUME[Turbofan]/smokePosition[0]$,$../../../PLUME[Turbofan]/smokePosition[1]$,$../../../PLUME[Turbofan]/smokePosition[2]$
-                //
-                name = smoke
-                modelName = RealPlume/MP_Nazari_FX/smokejet
-                fixedEmissions = false
-                sizeClamp = 50
-                randomInitalVelocityOffsetMaxRadius = 0.5
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 20
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 0.0
-                  density = 0.8 2
-                  density = 0.46 3
-                  density = 0.2 3
-                  density = 0.1 4
-                  density = 0.0 5
-                }
-                linGrow
-                {
-                  density = 1.0 0
-                  density = 0.46 0.0
-                  density = 0.2 0
-                  density = 0.05 30
-                  density = 0.0 40
-                }
-                grow
-                {
-                  density = 1 0
-                  density = 0.2 0
-                  density = 0.1 4
-                  density = 0 9
-                }
-                speed
-                {
-                  density = 1.0 1.7
-                  density = 0.46 1.7
-                  density = 0.2 1.5
-                  density = 0.05 1.5
-                  density = 0.0 1.5
-                }
-                emission
-                {
-                   density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
-                  density = 0.0 0
-                }
-            }
+	%EFFECTS
+	{
+		%Turbofan-Spool
+		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -228,9 +113,10 @@
 				pitch = 1.0 1.0
 				loop = true
 			}
-        }
-		engage
+		}
+		%engage
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -240,8 +126,9 @@
 				loop = false
 			}
 		}
-		disengage
+		%disengage
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -251,22 +138,5 @@
 				loop = false
 			}
 		}
-		flameout
-		{
-			PREFAB_PARTICLE
-			{
-				prefabName = fx_exhaustSparks_flameout_2
-				transformName = smokePoint
-				oneShot = true
-			}
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-    }
+	}
 }

--- a/GameData/JetSoundsUpdated/Patches/Juno.cfg
+++ b/GameData/JetSoundsUpdated/Patches/Juno.cfg
@@ -65,134 +65,18 @@
 	}
 }
 
-@PART[miniJetEngine]:NEEDS[RealPlume]:FOR[zzJetSounds]
+@PART[miniJetEngine]:AFTER[zzRealPlume]
 {
-    %EFFECTS
-    {
-        %Turbofan
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                
-                transformName = #$../../../PLUME[Turbofan]/transformName$
-                localRotation = #$../../../PLUME[Turbofan]/localRotation[0]$,$../../../PLUME[Turbofan]/localRotation[1]$,$../../../PLUME[Turbofan]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbofan]/plumePosition[0]$,$../../../PLUME[Turbofan]/plumePosition[1]$,$../../../PLUME[Turbofan]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbofan]/plumeScale$
-                energy        = #$../../../PLUME[Turbofan]/energy$
-                speed         = #$../../../PLUME[Turbofan]/speed$
-                emissionMult  = #$../../../PLUME[Turbofan]/emissionMult$
-                //
-                name = plume
-                modelName = RealPlume/MP_Nazari_FX/flamejet3
-                speed = 0.0 1.45
-                speed = 1.0 1.45
-                energy = 0.0 0.05
-                energy = 0.5 0.4
-                energy = 1.0 0.7
-                fixedEmissions = false
-                randConeEmit
-                {
-                  density = 1 0
-                  density = 0 0.5
-                }
-                energy
-                {
-                  density = 1 0.5
-                  density = 0 0.2
-                }
-                emission
-                {
-                  density = 1 1
-                  density = 0 0.5
-                  power = 0.0 0.0
-                  power = 0.42 0.0
-                  power = 0.54 1.55
-                  power = 1.0 1.78
-                }
-                speed
-                {
-                  density = 1 1.2
-                  density = 0 1.5
-                }
-            }
-        }
-        %Turbofan-Spool
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Turbofan]/transformName$
-                fixedScale    = #$../../../PLUME[Turbofan]/smokeScale$
-                localPosition = #$../../../PLUME[Turbofan]/smokePosition[0]$,$../../../PLUME[Turbofan]/smokePosition[1]$,$../../../PLUME[Turbofan]/smokePosition[2]$
-                //
-                name = smoke
-                modelName = RealPlume/MP_Nazari_FX/smokejet
-                fixedEmissions = false
-                sizeClamp = 50
-                randomInitalVelocityOffsetMaxRadius = 0.5
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 20
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 0.0
-                  density = 0.8 2
-                  density = 0.46 3
-                  density = 0.2 3
-                  density = 0.1 4
-                  density = 0.0 5
-                }
-                linGrow
-                {
-                  density = 1.0 0
-                  density = 0.46 0.0
-                  density = 0.2 0
-                  density = 0.05 30
-                  density = 0.0 40
-                }
-                grow
-                {
-                  density = 1 0
-                  density = 0.2 0
-                  density = 0.1 4
-                  density = 0 9
-                }
-                speed
-                {
-                  density = 1.0 1.7
-                  density = 0.46 1.7
-                  density = 0.2 1.5
-                  density = 0.05 1.5
-                  density = 0.0 1.5
-                }
-                emission
-                {
-                   density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
-                  density = 0.0 0
-                }
-            }
-            AUDIO
-            {
-                name = sndjet1
-                channel = Ship
-                clip = JetSoundsUpdated/Sounds/TFE731_Running_Low
+	%EFFECTS
+	{
+		%Turbofan-Spool
+		{
+			!AUDIO,* {}
+			AUDIO
+			{
+				name = sndjet1
+				channel = Ship
+				clip = JetSoundsUpdated/Sounds/TFE731_Running_Low
 				volume = 0.0 0.0
 				volume = 0.05 0.35
 				volume = 1.0 0.5
@@ -200,34 +84,35 @@
 				pitch = 0.05 0.8
 				pitch = 1.0 1.5
 				loop = true
-            }
-            AUDIO
-            {
-                name = sndjet2
-                channel = Ship
-                clip = JetSoundsUpdated/Sounds/TFE731_Running_High
+			}
+			AUDIO
+			{
+				name = sndjet2
+				channel = Ship
+				clip = JetSoundsUpdated/Sounds/TFE731_Running_High
 				volume = 0.0 0.0
 				volume = 0.05 0.2
 				volume = 1.0 0.5
 				pitch = 0.0 1.2
 				pitch = 1.0 2.0
 				loop = true
-            }
-        }
-		engage
+			}
+		}
+		%engage
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
-
 				clip = JetSoundsUpdated/Sounds/TFE731_Startup
 				volume = 0.8
 				pitch = 2.5
 				loop = false
 			}
 		}
-		disengage
+		%disengage
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -237,22 +122,5 @@
 				loop = false
 			}
 		}
-		flameout
-		{
-			PREFAB_PARTICLE
-			{
-				prefabName = fx_exhaustSparks_flameout_2
-				transformName = smokePoint
-				oneShot = true
-			}
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-    }
+	}
 }

--- a/GameData/JetSoundsUpdated/Patches/NuclearJet.cfg
+++ b/GameData/JetSoundsUpdated/Patches/NuclearJet.cfg
@@ -2,7 +2,7 @@
 //---Wheesley config by JeanTheDragon and PlumeParty/PlumeParty/RealPlume compatibility by theonegalen
 
  
-@PART[NuclearJetEngine]:NEEDS[!RealPlume,!PlumeParty]
+@PART[NuclearJetEngine]:NEEDS[!RealPlume]
 {
 	@EFFECTS
 	{		
@@ -61,33 +61,7 @@
 				loop = false
 			}
 		}
-	}
-}
-
-@PART[NuclearJetEngine]:NEEDS[AirplanePlus,!RealPlume,!PlumeParty]
-{
-	@EFFECTS
-	{		
-		@flameout
-		{
-			!AUDIO {}
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-	}
-}
-
-@PART[NuclearJetEngine]:NEEDS[AirplanePlus]:AFTER[PlumeParty]
-{
-	@EFFECTS
-	{		
-		@flameout
+		%flameout
 		{
 			!AUDIO {}
 			AUDIO

--- a/GameData/JetSoundsUpdated/Patches/Panther.cfg
+++ b/GameData/JetSoundsUpdated/Patches/Panther.cfg
@@ -3,11 +3,11 @@
 
 @PART[turboJet]
 {
-    @MODULE[ModuleEngines*],0
-    {
-        %engageEffectName = engageDry
+	@MODULE[ModuleEngines*],0
+	{
+		%engageEffectName = engageDry
 		%disengageEffectName = disengageDry
-    }
+	}
 }
  
 @PART[turboJet]:NEEDS[!RealPlume]
@@ -83,6 +83,7 @@
 		}
 		%engageDry
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -94,6 +95,7 @@
 		}
 		%disengageDry
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -127,14 +129,7 @@
 				loop = false
 			}
 		}
-	}
-}
-
-@PART[turboJet]:NEEDS[AirplanePlus]:AFTER[PlumeParty]
-{
-	@EFFECTS
-	{		
-		@flameout
+		%flameout
 		{
 			!AUDIO {}
 			AUDIO
@@ -149,129 +144,13 @@
 	}
 }
 
-@PART[turboJet]:NEEDS[RealPlume]:FOR[zzJetSounds]
+@PART[turboJet]:AFTER[zzRealPlume]
 {
-    %EFFECTS
-    {
-        %Turbofan
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                
-                transformName = #$../../../PLUME[Turbofan]/transformName$
-                localRotation = #$../../../PLUME[Turbofan]/localRotation[0]$,$../../../PLUME[Turbofan]/localRotation[1]$,$../../../PLUME[Turbofan]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbofan]/plumePosition[0]$,$../../../PLUME[Turbofan]/plumePosition[1]$,$../../../PLUME[Turbofan]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbofan]/plumeScale$
-                energy        = #$../../../PLUME[Turbofan]/energy$
-                speed         = #$../../../PLUME[Turbofan]/speed$
-                emissionMult  = #$../../../PLUME[Turbofan]/emissionMult$
-                //
-                name = plume
-                modelName = RealPlume/MP_Nazari_FX/flamejet3
-                speed = 0.0 1.45
-                speed = 1.0 1.45
-                energy = 0.0 0.05
-                energy = 0.5 0.4
-                energy = 1.0 0.7
-                fixedEmissions = false
-                randConeEmit
-                {
-                  density = 1 0
-                  density = 0 0.5
-                }
-                energy
-                {
-                  density = 1 0.5
-                  density = 0 0.2
-                }
-                emission
-                {
-                  density = 1 1
-                  density = 0 0.5
-                  power = 0.0 0.0
-                  power = 0.42 0.0
-                  power = 0.54 1.55
-                  power = 1.0 1.78
-                }
-                speed
-                {
-                  density = 1 1.2
-                  density = 0 1.5
-                }
-            }
-        }
-        %Turbofan-Spool
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Turbofan]/transformName$
-                fixedScale    = #$../../../PLUME[Turbofan]/smokeScale$
-                localPosition = #$../../../PLUME[Turbofan]/smokePosition[0]$,$../../../PLUME[Turbofan]/smokePosition[1]$,$../../../PLUME[Turbofan]/smokePosition[2]$
-                //
-                name = smoke
-                modelName = RealPlume/MP_Nazari_FX/smokejet
-                fixedEmissions = false
-                sizeClamp = 50
-                randomInitalVelocityOffsetMaxRadius = 0.5
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 20
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 0.0
-                  density = 0.8 2
-                  density = 0.46 3
-                  density = 0.2 3
-                  density = 0.1 4
-                  density = 0.0 5
-                }
-                linGrow
-                {
-                  density = 1.0 0
-                  density = 0.46 0.0
-                  density = 0.2 0
-                  density = 0.05 30
-                  density = 0.0 40
-                }
-                grow
-                {
-                  density = 1 0
-                  density = 0.2 0
-                  density = 0.1 4
-                  density = 0 9
-                }
-                speed
-                {
-                  density = 1.0 1.7
-                  density = 0.46 1.7
-                  density = 0.2 1.5
-                  density = 0.05 1.5
-                  density = 0.0 1.5
-                }
-                emission
-                {
-                   density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
-                  density = 0.0 0
-                }
-            }
+	%EFFECTS
+	{
+		%Turbofan-Spool
+		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -295,9 +174,10 @@
 				pitch = 1.0 1.0
 				loop = true
 			}
-        }
-		engageDry
+		}
+		%engageDry
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -307,8 +187,9 @@
 				loop = false
 			}
 		}
-		disengageDry
+		%disengageDry
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -318,190 +199,12 @@
 				loop = false
 			}
 		}
-		flameout
+	}
+	%EFFECTS
+	{
+		%Turbojet-Spool
 		{
-			PREFAB_PARTICLE
-			{
-				prefabName = fx_exhaustSparks_flameout_2
-				transformName = smokePoint
-				oneShot = true
-			}
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-    }
-    %EFFECTS
-    {
-        %Turbojet
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get configs from the PLUME node.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbojet]/flarePosition[0]$,$../../../PLUME[Turbojet]/flarePosition[1]$,$../../../PLUME[Turbojet]/flarePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbojet]/flareScale$
-                energy        = #$../../../PLUME[Turbojet]/energy$
-                speed         = #$../../../PLUME[Turbojet]/speed$
-                emissionMult  = #$../../../PLUME[Turbojet]/emissionMult$
-                //
-                name = flare
-                modelName = RealPlume/MP_Nazari_FX/flamejet3
-                emission = 0.0 0.0
-                emission = 0.42 0.0
-                emission = 0.54 1.55
-                emission = 1.0 1.78
-                speed = 0.0 1.45
-                speed = 1.0 1.45
-                energy = 0.0 0.05
-                energy = 0.5 0.77
-                energy = 1.0 0.99
-                fixedEmissions = false
-				emission
-				{
-				  density = 1 1
-				  density = 0.2 0.7
-				  density = 0.0 0.3
-				  power = 0.0 0.0
-				  power = 0.42 0.0
-				  power = 0.54 1.55
-				  power = 1.0 1.78
-				}
-				energy
-				{
-				  density = 1 1
-				  density = 0.2 0.7
-				  density = 0.0 0.3
-				}
-            }
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get configs from the PLUME node.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbojet]/plumePosition[0]$,$../../../PLUME[Turbojet]/plumePosition[1]$,$../../../PLUME[Turbojet]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbojet]/plumeScale$
-                energy        = #$../../../PLUME[Turbojet]/energy$
-                speed         = #$../../../PLUME[Turbojet]/speed$
-                //
-                name = afterburner
-                modelName = RealPlume/MP_Nazari_FX/methanolflame
-                emission = 0.0 0.0
-                emission = 0.42 0.0
-                emission = 0.74 0.0
-                emission = 0.84 1.0
-                emission = 1.0 1.78
-                speed = 0.0 1.3
-                speed = 1.0 1.3
-                energy = 0.0 0.00
-                energy = 0.7 0.05
-                energy = 1.0 0.99
-                fixedEmissions = false
-                offset = 1.5
-                size = 0.7
-                logGrow
-                {
-                  density = 1 0
-                  density = 0.3 2
-                  density = 0.0 20
-                }
-                emission
-                {
-                  density = 1 2
-                  density = 0.2 1.5
-                  density = 0.0 0.2
-                  power = 0.0 0.0
-                  power = 0.42 0.0
-                  power = 0.74 0.0
-                  power = 0.84 1.0
-                  power = 1.0 1.78
-                }
-                energy
-                {
-                  density = 1 1
-                  density = 0.2 0.7
-                  density = 0.0 0.2
-                }
-            }
-        }
-        %Turbojet-Spool
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                fixedScale    = #$../../../PLUME[Turbojet]/smokeScale$
-                localPosition = #$../../../PLUME[Turbojet]/smokePosition[0]$,$../../../PLUME[Turbojet]/smokePosition[1]$,$../../../PLUME[Turbojet]/smokePosition[2]$
-                //
-                name = smoke
-                modelName = RealPlume/MP_Nazari_FX/smokejet
-                fixedEmissions = false
-                sizeClamp = 50
-                randomInitalVelocityOffsetMaxRadius = 0.5
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 20
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 0.0
-                  density = 0.8 2
-                  density = 0.46 3
-                  density = 0.2 3
-                  density = 0.1 4
-                  density = 0.0 5
-                }
-                linGrow
-                {
-                  density = 1.0 0
-                  density = 0.46 0.0
-                  density = 0.2 0
-                  density = 0.05 30
-                  density = 0.0 40
-                }
-                grow
-                {
-                  density = 1 0
-                  density = 0.2 0
-                  density = 0.1 4
-                  density = 0 9
-                }
-                speed
-                {
-                  density = 1.0 1.7
-                  density = 0.46 1.7
-                  density = 0.2 1.5
-                  density = 0.05 1.5
-                  density = 0.0 1.5
-                }
-                emission
-                {
-                  density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
-                  density = 0.0 0
-                }
-            }
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -527,9 +230,10 @@
 				pitch = 1.0 1.5
 				loop = true
 			}
-        }
-        engage
+		}
+		%engage
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -539,22 +243,5 @@
 				loop = false
 			}
 		}
-		flameout
-		{
-			PREFAB_PARTICLE
-			{
-				prefabName = fx_exhaustSparks_flameout_2
-				transformName = smokePoint
-				oneShot = true
-			}
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-    }
+	}
 }

--- a/GameData/JetSoundsUpdated/Patches/RAPIER.cfg
+++ b/GameData/JetSoundsUpdated/Patches/RAPIER.cfg
@@ -3,17 +3,17 @@
 
 @PART[RAPIER]
 {
-    @MODULE[ModuleEngines*],0
-    {
-        %engageEffectName = engageDry
+	@MODULE[ModuleEngines*],0
+	{
+		%engageEffectName = engageDry
 		%disengageEffectName = disengageDry
-    }
-    @MODULE[ModuleEngines*],1
-    {
+	}
+	@MODULE[ModuleEngines*],1
+	{
 		%spoolEffectName = power_closed
-        %engageEffectName = engageRocket
+		%engageEffectName = engageRocket
 		%disengageEffectName = disengageRocket
-    }
+	}
 }
 
 @PART[RAPIER]:NEEDS[!RealPlume]
@@ -140,174 +140,13 @@
 	}
 }
 
-@PART[RAPIER]:NEEDS[RealPlume]:FOR[zzJetSounds]
+@PART[RAPIER]:AFTER[zzRealPlume]
 {
-    %EFFECTS
-    {
-        %Methalox_AirBreathingMode
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get configs from the PLUME node.
-                transformName = #$../../../PLUME[Methalox_AirBreathingMode]/transformName$
-                localRotation = #$../../../PLUME[Methalox_AirBreathingMode]/localRotation[0]$,$../../../PLUME[Methalox_AirBreathingMode]/localRotation[1]$,$../../../PLUME[Methalox_AirBreathingMode]/localRotation[2]$
-                localPosition = #$../../../PLUME[Methalox_AirBreathingMode]/flarePosition[0]$,$../../../PLUME[Methalox_AirBreathingMode]/flarePosition[1]$,$../../../PLUME[Methalox_AirBreathingMode]/flarePosition[2]$
-                fixedScale    = #$../../../PLUME[Methalox_AirBreathingMode]/flareScale$
-                energy        = #$../../../PLUME[Methalox_AirBreathingMode]/energy$
-                speed         = #$../../../PLUME[Methalox_AirBreathingMode]/speed$
-                emissionMult  = #$../../../PLUME[Methalox_AirBreathingMode]/emissionMult$
-                //
-                name = flare
-                modelName = RealPlume/MP_Nazari_FX/flamejet3
-                emission = 0.0 0.0
-                emission = 0.42 0.0
-                emission = 0.54 1.55
-                emission = 1.0 1.78
-                speed = 0.0 1.45
-                speed = 1.0 1.45
-                energy = 0.0 0.05
-                energy = 0.5 0.77
-                energy = 1.0 0.99
-                fixedEmissions = false
-				emission
-				{
-				  density = 1 1
-				  density = 0.2 0.7
-				  density = 0.0 0.3
-				  power = 0.0 0.0
-				  power = 0.42 0.0
-				  power = 0.54 1.55
-				  power = 1.0 1.78
-				}
-				energy
-				{
-				  density = 1 1
-				  density = 0.2 0.7
-				  density = 0.0 0.3
-				}
-            }
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get configs from the PLUME node.
-                transformName = #$../../../PLUME[Methalox_AirBreathingMode]/transformName$
-                localRotation = #$../../../PLUME[Methalox_AirBreathingMode]/localRotation[0]$,$../../../PLUME[Methalox_AirBreathingMode]/localRotation[1]$,$../../../PLUME[Methalox_AirBreathingMode]/localRotation[2]$
-                localPosition = #$../../../PLUME[Methalox_AirBreathingMode]/plumePosition[0]$,$../../../PLUME[Methalox_AirBreathingMode]/plumePosition[1]$,$../../../PLUME[Methalox_AirBreathingMode]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Methalox_AirBreathingMode]/plumeScale$
-                energy        = #$../../../PLUME[Methalox_AirBreathingMode]/energy$
-                speed         = #$../../../PLUME[Methalox_AirBreathingMode]/speed$
-                //
-                name = afterburner
-                modelName = RealPlume/MP_Nazari_FX/methanolflame
-                emission = 0.0 0.0
-                emission = 0.42 0.0
-                emission = 0.74 0.0
-                emission = 0.84 1.0
-                emission = 1.0 1.78
-                speed = 0.0 1.3
-                speed = 1.0 1.3
-                energy = 0.0 0.00
-                energy = 0.7 0.05
-                energy = 1.0 0.99
-                fixedEmissions = false
-                offset = 1.5
-                size = 0.7
-                logGrow
-                {
-                  density = 1 0
-                  density = 0.3 2
-                  density = 0.0 20
-                }
-                emission
-                {
-                  density = 1 2
-                  density = 0.2 1.5
-                  density = 0.0 0.2
-                  power = 0.0 0.0
-                  power = 0.42 0.0
-                  power = 0.74 0.0
-                  power = 0.84 1.0
-                  power = 1.0 1.78
-                }
-                energy
-                {
-                  density = 1 1
-                  density = 0.2 0.7
-                  density = 0.0 0.2
-                }
-            }
-        }
-        %Methalox_AirBreathingMode-Spool
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Methalox_AirBreathingMode]/transformName$
-                fixedScale    = #$../../../PLUME[Methalox_AirBreathingMode]/smokeScale$
-                localPosition = #$../../../PLUME[Methalox_AirBreathingMode]/smokePosition[0]$,$../../../PLUME[Methalox_AirBreathingMode]/smokePosition[1]$,$../../../PLUME[Methalox_AirBreathingMode]/smokePosition[2]$
-                //
-                name = smoke
-                modelName = RealPlume/MP_Nazari_FX/smokejet
-                fixedEmissions = false
-                sizeClamp = 50
-                randomInitalVelocityOffsetMaxRadius = 0.5
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 20
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 0.0
-                  density = 0.8 2
-                  density = 0.46 3
-                  density = 0.2 3
-                  density = 0.1 4
-                  density = 0.0 5
-                }
-                linGrow
-                {
-                  density = 1.0 0
-                  density = 0.46 0.0
-                  density = 0.2 0
-                  density = 0.05 30
-                  density = 0.0 40
-                }
-                grow
-                {
-                  density = 1 0
-                  density = 0.2 0
-                  density = 0.1 4
-                  density = 0 9
-                }
-                speed
-                {
-                  density = 1.0 1.7
-                  density = 0.46 1.7
-                  density = 0.2 1.5
-                  density = 0.05 1.5
-                  density = 0.0 1.5
-                }
-                emission
-                {
-                  density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
-                  density = 0.0 0
-                }
-            }
+	%EFFECTS
+	{
+		%Methalox_AirBreathingMode-Spool
+		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -334,9 +173,10 @@
 				pitch = 1.0 1.5
 				loop = true
 			}
-        }
-		engageDry
+		}
+		%engageDry
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -346,8 +186,9 @@
 				loop = false
 			}
 		}
-		disengageDry
+		%disengageDry
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -357,19 +198,21 @@
 				loop = false
 			}
 		}
-		engageRocket
+		%engageRocket
 		{
-            AUDIO
-            {
-                channel = Ship
-                clip = RealPlume/KW_Sounds/sound_liq1
-                volume = #$../../../PLUME[Methalox_LowerShock]/plumeScale$
-                pitch = 2.0
-                loop = false
-            }
+			!AUDIO,* {}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealPlume/KW_Sounds/sound_liq1
+				volume = #$../../../PLUME[Methalox_LowerShock]/plumeScale$
+				pitch = 2.0
+				loop = false
+			}
 		}
-		disengageRocket
+		%disengageRocket
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -379,164 +222,23 @@
 				loop = false
 			}
 		}
-		flameout
+		%Methalox_LowerShock-Lower
 		{
-			PREFAB_PARTICLE
-			{
-				prefabName = fx_exhaustSparks_flameout_2
-				transformName = smokePoint
-				oneShot = true
-			}
 			AUDIO
 			{
 				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
+				clip = RealPlume/KW_Sounds/sound_altloop2
+				volume = 0.0 0.0
+				volume = #$../../../PLUME[Methalox_LowerShock]/plumeScale$
+				@volume,1 ^= :^:1.0 :
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}			
 		}
-        %Methalox_LowerShock-Lower
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Methalox_LowerShock]/transformName$
-                localRotation = #$../../../PLUME[Methalox_LowerShock]/localRotation[0]$,$../../../PLUME[Methalox_LowerShock]/localRotation[1]$,$../../../PLUME[Methalox_LowerShock]/localRotation[2]$
-                localPosition = #$../../../PLUME[Methalox_LowerShock]/flarePosition[0]$,$../../../PLUME[Methalox_LowerShock]/flarePosition[1]$,$../../../PLUME[Methalox_LowerShock]/flarePosition[2]$
-                fixedScale    = #$../../../PLUME[Methalox_LowerShock]/flareScale$
-                //
-                name = flare
-                modelName = RealPlume/Ferram_FX/hypergolicflare
-                emission = 0.0 0
-                emission = 0.01 0.2
-                emission = 1.0 2
-                speed = 0.0 1
-                speed = 1.0 1
-                offset = 0
-                energy = 0.0 0.5
-                energy = 1.0 0.5
-                size = 0.0 0.4
-                size = 1.0 0.4
-                fixedEmissions = false
-                randomInitalVelocityOffsetMaxRadius = 0.2
-                linGrow
-                {
-                  power = 1 15
-                  power = 0 15
-                }
-            }
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Methalox_LowerShock]/transformName$
-                localRotation = #$../../../PLUME[Methalox_LowerShock]/localRotation[0]$,$../../../PLUME[Methalox_LowerShock]/localRotation[1]$,$../../../PLUME[Methalox_LowerShock]/localRotation[2]$
-                localPosition = #$../../../PLUME[Methalox_LowerShock]/plumePosition[0]$,$../../../PLUME[Methalox_LowerShock]/plumePosition[1]$,$../../../PLUME[Methalox_LowerShock]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Methalox_LowerShock]/plumeScale$
-                energy        = #$../../../PLUME[Methalox_LowerShock]/energy$
-                speed         = #$../../../PLUME[Methalox_LowerShock]/speed$
-                emissionMult  = #$../../../PLUME[Methalox_LowerShock]/emissionMult$
-                //
-                name = plume
-                modelName = RealPlume/Ferram_FX/hypergolicexhaust
-                fixedEmissions = false
-                sizeClamp = 50
-                randConeEmit
-                {
-                  density = 1.0 0
-                  density = 0.5 0.3
-                  density = 0.25 0.9
-                  density = 0.06 0.9
-                  density = 0 1.4
-                }
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 2
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 1
-                  density = 0.8 3
-                  density = 0.46 4
-                  density = 0.2 10
-                  density = 0.1 5
-                  density = 0.0 4
-                }
-                linGrow
-                {
-                  density = 1.0 -0.2
-                  density = 0.8 0
-                  density = 0.46 1
-                  density = 0.2 7
-                  density = 0.05 12
-                  density = 0.0 14
-                }
-                speed
-                {
-                  density = 1.0 1
-                  density = 0.46 1.5
-                  density = 0.2 1.5
-                  density = 0.05 1.3
-                  density = 0.0 1.2
-                }
-                xyForce
-                {
-                  density = 1 0.65
-                  density = 0.5 0.85
-                  density = 0.25 0.9
-                  density = 0.06 0.95
-                  density = 0 1
-                }
-                zForce
-                {
-                  density = 1 1
-                  density = 0.2 1.02
-                  density = 0 1.033
-                }
-                emission
-                {
-                  density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1
-                  density = 0.05 1
-                  density = 0.0 1
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 1
-                  density = 0.3 1
-                  density = 0.2 1
-                  density = 0.05 0.7
-                  density = 0.0 0.3
-                }
-                size
-                {
-                  density = 1.0 0.85
-                  density = 0.8 0.85
-                  density = 0.2 0.75
-                  density = 0.0 0.75
-                }
-            }
-            AUDIO
-            {
-                channel = Ship
-                clip = RealPlume/KW_Sounds/sound_altloop2
-                volume = 0.0 0.0
-                volume = #$../../../PLUME[Methalox_LowerShock]/plumeScale$
-                @volume,1 ^= :^:1.0 :
-                pitch = 0.0 1.0
-                pitch = 1.0 1.0
-                loop = true
-            }            
-        }
-		power_closed
+		%power_closed
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -549,5 +251,5 @@
 				loop = true
 			}
 		}
-    }
+	}
 }

--- a/GameData/JetSoundsUpdated/Patches/SXTJaguar.cfg
+++ b/GameData/JetSoundsUpdated/Patches/SXTJaguar.cfg
@@ -3,11 +3,11 @@
 
 @PART[SXTVTOLturboFan]
 {
-    @MODULE[ModuleEngines*],0
-    {
-        %engageEffectName = engageDry
+	@MODULE[ModuleEngines*],0
+	{
+		%engageEffectName = engageDry
 		%disengageEffectName = disengageDry
-    }
+	}
 }
  
 @PART[SXTVTOLturboFan]:NEEDS[!RealPlume]
@@ -132,129 +132,129 @@
 	}
 }
 
-@PART[SXTVTOLturboFan]:NEEDS[RealPlume]:FOR[zzJetSounds]
+@PART[SXTVTOLturboFan]:AFTER[zzRealPlume]
 {
-    %EFFECTS
-    {
-        %Turbofan
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                
-                transformName = #$../../../PLUME[Turbofan]/transformName$
-                localRotation = #$../../../PLUME[Turbofan]/localRotation[0]$,$../../../PLUME[Turbofan]/localRotation[1]$,$../../../PLUME[Turbofan]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbofan]/plumePosition[0]$,$../../../PLUME[Turbofan]/plumePosition[1]$,$../../../PLUME[Turbofan]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbofan]/plumeScale$
-                energy        = #$../../../PLUME[Turbofan]/energy$
-                speed         = #$../../../PLUME[Turbofan]/speed$
-                emissionMult  = #$../../../PLUME[Turbofan]/emissionMult$
-                //
-                name = plume
-                modelName = RealPlume/MP_Nazari_FX/flamejet3
-                speed = 0.0 1.45
-                speed = 1.0 1.45
-                energy = 0.0 0.05
-                energy = 0.5 0.4
-                energy = 1.0 0.7
-                fixedEmissions = false
-                randConeEmit
-                {
-                  density = 1 0
-                  density = 0 0.5
-                }
-                energy
-                {
-                  density = 1 0.5
-                  density = 0 0.2
-                }
-                emission
-                {
-                  density = 1 1
-                  density = 0 0.5
-                  power = 0.0 0.0
-                  power = 0.42 0.0
-                  power = 0.54 1.55
-                  power = 1.0 1.78
-                }
-                speed
-                {
-                  density = 1 1.2
-                  density = 0 1.5
-                }
-            }
-        }
-        %Turbofan-Spool
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Turbofan]/transformName$
-                fixedScale    = #$../../../PLUME[Turbofan]/smokeScale$
-                localPosition = #$../../../PLUME[Turbofan]/smokePosition[0]$,$../../../PLUME[Turbofan]/smokePosition[1]$,$../../../PLUME[Turbofan]/smokePosition[2]$
-                //
-                name = smoke
-                modelName = RealPlume/MP_Nazari_FX/smokejet
-                fixedEmissions = false
-                sizeClamp = 50
-                randomInitalVelocityOffsetMaxRadius = 0.5
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 20
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 0.0
-                  density = 0.8 2
-                  density = 0.46 3
-                  density = 0.2 3
-                  density = 0.1 4
-                  density = 0.0 5
-                }
-                linGrow
-                {
-                  density = 1.0 0
-                  density = 0.46 0.0
-                  density = 0.2 0
-                  density = 0.05 30
-                  density = 0.0 40
-                }
-                grow
-                {
-                  density = 1 0
-                  density = 0.2 0
-                  density = 0.1 4
-                  density = 0 9
-                }
-                speed
-                {
-                  density = 1.0 1.7
-                  density = 0.46 1.7
-                  density = 0.2 1.5
-                  density = 0.05 1.5
-                  density = 0.0 1.5
-                }
-                emission
-                {
-                   density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
-                  density = 0.0 0
-                }
-            }
+	%EFFECTS
+	{
+		%Turbofan
+		{
+			MODEL_MULTI_SHURIKEN_PERSIST
+			{
+				
+				transformName = #$../../../PLUME[Turbofan]/transformName$
+				localRotation = #$../../../PLUME[Turbofan]/localRotation[0]$,$../../../PLUME[Turbofan]/localRotation[1]$,$../../../PLUME[Turbofan]/localRotation[2]$
+				localPosition = #$../../../PLUME[Turbofan]/plumePosition[0]$,$../../../PLUME[Turbofan]/plumePosition[1]$,$../../../PLUME[Turbofan]/plumePosition[2]$
+				fixedScale	= #$../../../PLUME[Turbofan]/plumeScale$
+				energy		= #$../../../PLUME[Turbofan]/energy$
+				speed		 = #$../../../PLUME[Turbofan]/speed$
+				emissionMult  = #$../../../PLUME[Turbofan]/emissionMult$
+				//
+				name = plume
+				modelName = RealPlume/MP_Nazari_FX/flamejet3
+				speed = 0.0 1.45
+				speed = 1.0 1.45
+				energy = 0.0 0.05
+				energy = 0.5 0.4
+				energy = 1.0 0.7
+				fixedEmissions = false
+				randConeEmit
+				{
+				  density = 1 0
+				  density = 0 0.5
+				}
+				energy
+				{
+				  density = 1 0.5
+				  density = 0 0.2
+				}
+				emission
+				{
+				  density = 1 1
+				  density = 0 0.5
+				  power = 0.0 0.0
+				  power = 0.42 0.0
+				  power = 0.54 1.55
+				  power = 1.0 1.78
+				}
+				speed
+				{
+				  density = 1 1.2
+				  density = 0 1.5
+				}
+			}
+		}
+		%Turbofan-Spool
+		{
+			MODEL_MULTI_SHURIKEN_PERSIST
+			{
+				//Get the inputs from the other config.
+				transformName = #$../../../PLUME[Turbofan]/transformName$
+				fixedScale	= #$../../../PLUME[Turbofan]/smokeScale$
+				localPosition = #$../../../PLUME[Turbofan]/smokePosition[0]$,$../../../PLUME[Turbofan]/smokePosition[1]$,$../../../PLUME[Turbofan]/smokePosition[2]$
+				//
+				name = smoke
+				modelName = RealPlume/MP_Nazari_FX/smokejet
+				fixedEmissions = false
+				sizeClamp = 50
+				randomInitalVelocityOffsetMaxRadius = 0.5
+				logGrow
+				{
+				  density = 1.0 2
+				  density = 0.1 20
+				  density = 0.0 2
+				}
+				logGrowScale
+				{
+				  density = 1.0 0.0
+				  density = 0.8 2
+				  density = 0.46 3
+				  density = 0.2 3
+				  density = 0.1 4
+				  density = 0.0 5
+				}
+				linGrow
+				{
+				  density = 1.0 0
+				  density = 0.46 0.0
+				  density = 0.2 0
+				  density = 0.05 30
+				  density = 0.0 40
+				}
+				grow
+				{
+				  density = 1 0
+				  density = 0.2 0
+				  density = 0.1 4
+				  density = 0 9
+				}
+				speed
+				{
+				  density = 1.0 1.7
+				  density = 0.46 1.7
+				  density = 0.2 1.5
+				  density = 0.05 1.5
+				  density = 0.0 1.5
+				}
+				emission
+				{
+				   density = 1.0 2
+				  density = 0.8 1.2
+				  density = 0.2 1
+				  density = 0.1 1.2
+				  density = 0.05 1.5
+				  density = 0.0 1.7
+				  power = 1 1
+				  power = 0.01 0.2
+				  power = 0 0
+				}
+				energy
+				{
+				  density = 1.0 2
+				  density = 0.3 2
+				  density = 0.05 1
+				  density = 0.0 0
+				}
+			}
 			AUDIO
 			{
 				channel = Ship
@@ -278,7 +278,7 @@
 				pitch = 1.0 1.0
 				loop = true
 			}
-        }
+		}
 		engageDry
 		{
 			AUDIO
@@ -318,34 +318,34 @@
 				loop = false
 			}
 		}
-    }
-    %EFFECTS
-    {
-        %Turbojet
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get configs from the PLUME node.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbojet]/flarePosition[0]$,$../../../PLUME[Turbojet]/flarePosition[1]$,$../../../PLUME[Turbojet]/flarePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbojet]/flareScale$
-                energy        = #$../../../PLUME[Turbojet]/energy$
-                speed         = #$../../../PLUME[Turbojet]/speed$
-                emissionMult  = #$../../../PLUME[Turbojet]/emissionMult$
-                //
-                name = flare
-                modelName = RealPlume/MP_Nazari_FX/flamejet3
-                emission = 0.0 0.0
-                emission = 0.42 0.0
-                emission = 0.54 1.55
-                emission = 1.0 1.78
-                speed = 0.0 1.45
-                speed = 1.0 1.45
-                energy = 0.0 0.05
-                energy = 0.5 0.77
-                energy = 1.0 0.99
-                fixedEmissions = false
+	}
+	%EFFECTS
+	{
+		%Turbojet
+		{
+			MODEL_MULTI_SHURIKEN_PERSIST
+			{
+				//Get configs from the PLUME node.
+				transformName = #$../../../PLUME[Turbojet]/transformName$
+				localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
+				localPosition = #$../../../PLUME[Turbojet]/flarePosition[0]$,$../../../PLUME[Turbojet]/flarePosition[1]$,$../../../PLUME[Turbojet]/flarePosition[2]$
+				fixedScale	= #$../../../PLUME[Turbojet]/flareScale$
+				energy		= #$../../../PLUME[Turbojet]/energy$
+				speed		 = #$../../../PLUME[Turbojet]/speed$
+				emissionMult  = #$../../../PLUME[Turbojet]/emissionMult$
+				//
+				name = flare
+				modelName = RealPlume/MP_Nazari_FX/flamejet3
+				emission = 0.0 0.0
+				emission = 0.42 0.0
+				emission = 0.54 1.55
+				emission = 1.0 1.78
+				speed = 0.0 1.45
+				speed = 1.0 1.45
+				energy = 0.0 0.05
+				energy = 0.5 0.77
+				energy = 1.0 0.99
+				fixedEmissions = false
 				emission
 				{
 				  density = 1 1
@@ -362,129 +362,129 @@
 				  density = 0.2 0.7
 				  density = 0.0 0.3
 				}
-            }
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get configs from the PLUME node.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbojet]/plumePosition[0]$,$../../../PLUME[Turbojet]/plumePosition[1]$,$../../../PLUME[Turbojet]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbojet]/plumeScale$
-                energy        = #$../../../PLUME[Turbojet]/energy$
-                speed         = #$../../../PLUME[Turbojet]/speed$
-                //
-                name = afterburner
-                modelName = RealPlume/MP_Nazari_FX/methanolflame
-                emission = 0.0 0.0
-                emission = 0.42 0.0
-                emission = 0.74 0.0
-                emission = 0.84 1.0
-                emission = 1.0 1.78
-                speed = 0.0 1.3
-                speed = 1.0 1.3
-                energy = 0.0 0.00
-                energy = 0.7 0.05
-                energy = 1.0 0.99
-                fixedEmissions = false
-                offset = 1.5
-                size = 0.7
-                logGrow
-                {
-                  density = 1 0
-                  density = 0.3 2
-                  density = 0.0 20
-                }
-                emission
-                {
-                  density = 1 2
-                  density = 0.2 1.5
-                  density = 0.0 0.2
-                  power = 0.0 0.0
-                  power = 0.42 0.0
-                  power = 0.74 0.0
-                  power = 0.84 1.0
-                  power = 1.0 1.78
-                }
-                energy
-                {
-                  density = 1 1
-                  density = 0.2 0.7
-                  density = 0.0 0.2
-                }
-            }
-        }
-        %Turbojet-Spool
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                fixedScale    = #$../../../PLUME[Turbojet]/smokeScale$
-                localPosition = #$../../../PLUME[Turbojet]/smokePosition[0]$,$../../../PLUME[Turbojet]/smokePosition[1]$,$../../../PLUME[Turbojet]/smokePosition[2]$
-                //
-                name = smoke
-                modelName = RealPlume/MP_Nazari_FX/smokejet
-                fixedEmissions = false
-                sizeClamp = 50
-                randomInitalVelocityOffsetMaxRadius = 0.5
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 20
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 0.0
-                  density = 0.8 2
-                  density = 0.46 3
-                  density = 0.2 3
-                  density = 0.1 4
-                  density = 0.0 5
-                }
-                linGrow
-                {
-                  density = 1.0 0
-                  density = 0.46 0.0
-                  density = 0.2 0
-                  density = 0.05 30
-                  density = 0.0 40
-                }
-                grow
-                {
-                  density = 1 0
-                  density = 0.2 0
-                  density = 0.1 4
-                  density = 0 9
-                }
-                speed
-                {
-                  density = 1.0 1.7
-                  density = 0.46 1.7
-                  density = 0.2 1.5
-                  density = 0.05 1.5
-                  density = 0.0 1.5
-                }
-                emission
-                {
-                  density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
-                  density = 0.0 0
-                }
-            }
+			}
+			MODEL_MULTI_SHURIKEN_PERSIST
+			{
+				//Get configs from the PLUME node.
+				transformName = #$../../../PLUME[Turbojet]/transformName$
+				localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
+				localPosition = #$../../../PLUME[Turbojet]/plumePosition[0]$,$../../../PLUME[Turbojet]/plumePosition[1]$,$../../../PLUME[Turbojet]/plumePosition[2]$
+				fixedScale	= #$../../../PLUME[Turbojet]/plumeScale$
+				energy		= #$../../../PLUME[Turbojet]/energy$
+				speed		 = #$../../../PLUME[Turbojet]/speed$
+				//
+				name = afterburner
+				modelName = RealPlume/MP_Nazari_FX/methanolflame
+				emission = 0.0 0.0
+				emission = 0.42 0.0
+				emission = 0.74 0.0
+				emission = 0.84 1.0
+				emission = 1.0 1.78
+				speed = 0.0 1.3
+				speed = 1.0 1.3
+				energy = 0.0 0.00
+				energy = 0.7 0.05
+				energy = 1.0 0.99
+				fixedEmissions = false
+				offset = 1.5
+				size = 0.7
+				logGrow
+				{
+				  density = 1 0
+				  density = 0.3 2
+				  density = 0.0 20
+				}
+				emission
+				{
+				  density = 1 2
+				  density = 0.2 1.5
+				  density = 0.0 0.2
+				  power = 0.0 0.0
+				  power = 0.42 0.0
+				  power = 0.74 0.0
+				  power = 0.84 1.0
+				  power = 1.0 1.78
+				}
+				energy
+				{
+				  density = 1 1
+				  density = 0.2 0.7
+				  density = 0.0 0.2
+				}
+			}
+		}
+		%Turbojet-Spool
+		{
+			MODEL_MULTI_SHURIKEN_PERSIST
+			{
+				//Get the inputs from the other config.
+				transformName = #$../../../PLUME[Turbojet]/transformName$
+				fixedScale	= #$../../../PLUME[Turbojet]/smokeScale$
+				localPosition = #$../../../PLUME[Turbojet]/smokePosition[0]$,$../../../PLUME[Turbojet]/smokePosition[1]$,$../../../PLUME[Turbojet]/smokePosition[2]$
+				//
+				name = smoke
+				modelName = RealPlume/MP_Nazari_FX/smokejet
+				fixedEmissions = false
+				sizeClamp = 50
+				randomInitalVelocityOffsetMaxRadius = 0.5
+				logGrow
+				{
+				  density = 1.0 2
+				  density = 0.1 20
+				  density = 0.0 2
+				}
+				logGrowScale
+				{
+				  density = 1.0 0.0
+				  density = 0.8 2
+				  density = 0.46 3
+				  density = 0.2 3
+				  density = 0.1 4
+				  density = 0.0 5
+				}
+				linGrow
+				{
+				  density = 1.0 0
+				  density = 0.46 0.0
+				  density = 0.2 0
+				  density = 0.05 30
+				  density = 0.0 40
+				}
+				grow
+				{
+				  density = 1 0
+				  density = 0.2 0
+				  density = 0.1 4
+				  density = 0 9
+				}
+				speed
+				{
+				  density = 1.0 1.7
+				  density = 0.46 1.7
+				  density = 0.2 1.5
+				  density = 0.05 1.5
+				  density = 0.0 1.5
+				}
+				emission
+				{
+				  density = 1.0 2
+				  density = 0.8 1.2
+				  density = 0.2 1
+				  density = 0.1 1.2
+				  density = 0.05 1.5
+				  density = 0.0 1.7
+				  power = 1 1
+				  power = 0.01 0.2
+				  power = 0 0
+				}
+				energy
+				{
+				  density = 1.0 2
+				  density = 0.3 2
+				  density = 0.05 1
+				  density = 0.0 0
+				}
+			}
 			AUDIO
 			{
 				channel = Ship
@@ -510,8 +510,8 @@
 				pitch = 1.0 1.5
 				loop = true
 			}
-        }
-        engage
+		}
+		engage
 		{
 			AUDIO
 			{
@@ -539,5 +539,5 @@
 				loop = false
 			}
 		}
-    }
+	}
 }

--- a/GameData/JetSoundsUpdated/Patches/SXTLANCER.cfg
+++ b/GameData/JetSoundsUpdated/Patches/SXTLANCER.cfg
@@ -3,24 +3,24 @@
 
 @PART[SXTLANCER]
 {
-    @MODULE[ModuleEngines*],0
-    {
-        %engageEffectName = engageDry
+	@MODULE[ModuleEngines*],0
+	{
+		%engageEffectName = engageDry
 		%disengageEffectName = disengageDry
-    }
-    @MODULE[ModuleEngines*],1
-    {
-        %engageEffectName = engageRocket
+	}
+	@MODULE[ModuleEngines*],1
+	{
+		%engageEffectName = engageRocket
 		%disengageEffectName = disengageRocket
-    }
+	}
 }
 
 @PART[SXTLANCER]:NEEDS[!RealPlume]
 {
    @MODULE[ModuleEngines*],1
-    {
+	{
 		%spoolEffectName = power_closed
-    }
+	}
 	
 	@EFFECTS
 	{
@@ -134,35 +134,35 @@
 	}
 }
 
-@PART[SXTLANCER]:NEEDS[RealPlume]:FOR[zzJetSounds]
+@PART[SXTLANCER]:AFTER[zzRealPlume]
 {
-    %EFFECTS
-    {
-        %Turbojet
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get configs from the PLUME node.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbojet]/flarePosition[0]$,$../../../PLUME[Turbojet]/flarePosition[1]$,$../../../PLUME[Turbojet]/flarePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbojet]/flareScale$
-                energy        = #$../../../PLUME[Turbojet]/energy$
-                speed         = #$../../../PLUME[Turbojet]/speed$
-                emissionMult  = #$../../../PLUME[Turbojet]/emissionMult$
-                //
-                name = flare
-                modelName = RealPlume/MP_Nazari_FX/flamejet3
-                emission = 0.0 0.0
-                emission = 0.42 0.0
-                emission = 0.54 1.55
-                emission = 1.0 1.78
-                speed = 0.0 1.45
-                speed = 1.0 1.45
-                energy = 0.0 0.05
-                energy = 0.5 0.77
-                energy = 1.0 0.99
-                fixedEmissions = false
+	%EFFECTS
+	{
+		%Turbojet
+		{
+			MODEL_MULTI_SHURIKEN_PERSIST
+			{
+				//Get configs from the PLUME node.
+				transformName = #$../../../PLUME[Turbojet]/transformName$
+				localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
+				localPosition = #$../../../PLUME[Turbojet]/flarePosition[0]$,$../../../PLUME[Turbojet]/flarePosition[1]$,$../../../PLUME[Turbojet]/flarePosition[2]$
+				fixedScale	= #$../../../PLUME[Turbojet]/flareScale$
+				energy		= #$../../../PLUME[Turbojet]/energy$
+				speed		 = #$../../../PLUME[Turbojet]/speed$
+				emissionMult  = #$../../../PLUME[Turbojet]/emissionMult$
+				//
+				name = flare
+				modelName = RealPlume/MP_Nazari_FX/flamejet3
+				emission = 0.0 0.0
+				emission = 0.42 0.0
+				emission = 0.54 1.55
+				emission = 1.0 1.78
+				speed = 0.0 1.45
+				speed = 1.0 1.45
+				energy = 0.0 0.05
+				energy = 0.5 0.77
+				energy = 1.0 0.99
+				fixedEmissions = false
 				emission
 				{
 				  density = 1 1
@@ -179,129 +179,129 @@
 				  density = 0.2 0.7
 				  density = 0.0 0.3
 				}
-            }
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get configs from the PLUME node.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbojet]/plumePosition[0]$,$../../../PLUME[Turbojet]/plumePosition[1]$,$../../../PLUME[Turbojet]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbojet]/plumeScale$
-                energy        = #$../../../PLUME[Turbojet]/energy$
-                speed         = #$../../../PLUME[Turbojet]/speed$
-                //
-                name = afterburner
-                modelName = RealPlume/MP_Nazari_FX/methanolflame
-                emission = 0.0 0.0
-                emission = 0.42 0.0
-                emission = 0.74 0.0
-                emission = 0.84 1.0
-                emission = 1.0 1.78
-                speed = 0.0 1.3
-                speed = 1.0 1.3
-                energy = 0.0 0.00
-                energy = 0.7 0.05
-                energy = 1.0 0.99
-                fixedEmissions = false
-                offset = 1.5
-                size = 0.7
-                logGrow
-                {
-                  density = 1 0
-                  density = 0.3 2
-                  density = 0.0 20
-                }
-                emission
-                {
-                  density = 1 2
-                  density = 0.2 1.5
-                  density = 0.0 0.2
-                  power = 0.0 0.0
-                  power = 0.42 0.0
-                  power = 0.74 0.0
-                  power = 0.84 1.0
-                  power = 1.0 1.78
-                }
-                energy
-                {
-                  density = 1 1
-                  density = 0.2 0.7
-                  density = 0.0 0.2
-                }
-            }
-        }
-        %Turbojet-Spool
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                fixedScale    = #$../../../PLUME[Turbojet]/smokeScale$
-                localPosition = #$../../../PLUME[Turbojet]/smokePosition[0]$,$../../../PLUME[Turbojet]/smokePosition[1]$,$../../../PLUME[Turbojet]/smokePosition[2]$
-                //
-                name = smoke
-                modelName = RealPlume/MP_Nazari_FX/smokejet
-                fixedEmissions = false
-                sizeClamp = 50
-                randomInitalVelocityOffsetMaxRadius = 0.5
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 20
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 0.0
-                  density = 0.8 2
-                  density = 0.46 3
-                  density = 0.2 3
-                  density = 0.1 4
-                  density = 0.0 5
-                }
-                linGrow
-                {
-                  density = 1.0 0
-                  density = 0.46 0.0
-                  density = 0.2 0
-                  density = 0.05 30
-                  density = 0.0 40
-                }
-                grow
-                {
-                  density = 1 0
-                  density = 0.2 0
-                  density = 0.1 4
-                  density = 0 9
-                }
-                speed
-                {
-                  density = 1.0 1.7
-                  density = 0.46 1.7
-                  density = 0.2 1.5
-                  density = 0.05 1.5
-                  density = 0.0 1.5
-                }
-                emission
-                {
-                  density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
-                  density = 0.0 0
-                }
-            }
+			}
+			MODEL_MULTI_SHURIKEN_PERSIST
+			{
+				//Get configs from the PLUME node.
+				transformName = #$../../../PLUME[Turbojet]/transformName$
+				localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
+				localPosition = #$../../../PLUME[Turbojet]/plumePosition[0]$,$../../../PLUME[Turbojet]/plumePosition[1]$,$../../../PLUME[Turbojet]/plumePosition[2]$
+				fixedScale	= #$../../../PLUME[Turbojet]/plumeScale$
+				energy		= #$../../../PLUME[Turbojet]/energy$
+				speed		 = #$../../../PLUME[Turbojet]/speed$
+				//
+				name = afterburner
+				modelName = RealPlume/MP_Nazari_FX/methanolflame
+				emission = 0.0 0.0
+				emission = 0.42 0.0
+				emission = 0.74 0.0
+				emission = 0.84 1.0
+				emission = 1.0 1.78
+				speed = 0.0 1.3
+				speed = 1.0 1.3
+				energy = 0.0 0.00
+				energy = 0.7 0.05
+				energy = 1.0 0.99
+				fixedEmissions = false
+				offset = 1.5
+				size = 0.7
+				logGrow
+				{
+				  density = 1 0
+				  density = 0.3 2
+				  density = 0.0 20
+				}
+				emission
+				{
+				  density = 1 2
+				  density = 0.2 1.5
+				  density = 0.0 0.2
+				  power = 0.0 0.0
+				  power = 0.42 0.0
+				  power = 0.74 0.0
+				  power = 0.84 1.0
+				  power = 1.0 1.78
+				}
+				energy
+				{
+				  density = 1 1
+				  density = 0.2 0.7
+				  density = 0.0 0.2
+				}
+			}
+		}
+		%Turbojet-Spool
+		{
+			MODEL_MULTI_SHURIKEN_PERSIST
+			{
+				//Get the inputs from the other config.
+				transformName = #$../../../PLUME[Turbojet]/transformName$
+				fixedScale	= #$../../../PLUME[Turbojet]/smokeScale$
+				localPosition = #$../../../PLUME[Turbojet]/smokePosition[0]$,$../../../PLUME[Turbojet]/smokePosition[1]$,$../../../PLUME[Turbojet]/smokePosition[2]$
+				//
+				name = smoke
+				modelName = RealPlume/MP_Nazari_FX/smokejet
+				fixedEmissions = false
+				sizeClamp = 50
+				randomInitalVelocityOffsetMaxRadius = 0.5
+				logGrow
+				{
+				  density = 1.0 2
+				  density = 0.1 20
+				  density = 0.0 2
+				}
+				logGrowScale
+				{
+				  density = 1.0 0.0
+				  density = 0.8 2
+				  density = 0.46 3
+				  density = 0.2 3
+				  density = 0.1 4
+				  density = 0.0 5
+				}
+				linGrow
+				{
+				  density = 1.0 0
+				  density = 0.46 0.0
+				  density = 0.2 0
+				  density = 0.05 30
+				  density = 0.0 40
+				}
+				grow
+				{
+				  density = 1 0
+				  density = 0.2 0
+				  density = 0.1 4
+				  density = 0 9
+				}
+				speed
+				{
+				  density = 1.0 1.7
+				  density = 0.46 1.7
+				  density = 0.2 1.5
+				  density = 0.05 1.5
+				  density = 0.0 1.5
+				}
+				emission
+				{
+				  density = 1.0 2
+				  density = 0.8 1.2
+				  density = 0.2 1
+				  density = 0.1 1.2
+				  density = 0.05 1.5
+				  density = 0.0 1.7
+				  power = 1 1
+				  power = 0.01 0.2
+				  power = 0 0
+				}
+				energy
+				{
+				  density = 1.0 2
+				  density = 0.3 2
+				  density = 0.05 1
+				  density = 0.0 0
+				}
+			}
 			AUDIO
 			{
 				channel = Ship
@@ -328,7 +328,7 @@
 				pitch = 1.0 1.5
 				loop = true
 			}
-        }
+		}
 		engageDry
 		{
 			AUDIO
@@ -353,14 +353,14 @@
 		}
 		engageRocket
 		{
-            AUDIO
-            {
-                channel = Ship
-                clip = RealPlume/KW_Sounds/sound_liq1
-                volume = #$../../../PLUME[Hypergolic-Lower]/plumeScale$
-                pitch = 1.0
-                loop = false
-            }
+			AUDIO
+			{
+				channel = Ship
+				clip = RealPlume/KW_Sounds/sound_liq1
+				volume = #$../../../PLUME[Hypergolic-Lower]/plumeScale$
+				pitch = 1.0
+				loop = false
+			}
 		}
 		disengageRocket
 		{
@@ -390,145 +390,145 @@
 				loop = false
 			}
 		}
-        %Hypergolic-Lower
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Hypergolic-Lower]/transformName$
-                localRotation = #$../../../PLUME[Hypergolic-Lower]/localRotation[0]$,$../../../PLUME[Hypergolic-Lower]/localRotation[1]$,$../../../PLUME[Hypergolic-Lower]/localRotation[2]$
-                localPosition = #$../../../PLUME[Hypergolic-Lower]/flarePosition[0]$,$../../../PLUME[Hypergolic-Lower]/flarePosition[1]$,$../../../PLUME[Hypergolic-Lower]/flarePosition[2]$
-                fixedScale    = #$../../../PLUME[Hypergolic-Lower]/flareScale$
-                //
-                name = flare
-                modelName = RealPlume/Ferram_FX/hypergolicflare
-                emission = 0.0 0
-                emission = 0.01 0.2
-                emission = 1.0 2
-                speed = 0.0 1
-                speed = 1.0 1
-                offset = 0
-                energy = 0.0 0.5
-                energy = 1.0 0.5
-                size = 0.0 0.4
-                size = 1.0 0.4
-                fixedEmissions = false
-                randomInitalVelocityOffsetMaxRadius = 0.2
-                linGrow
-                {
-                  power = 1 15
-                  power = 0 15
-                }
-            }
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Hypergolic-Lower]/transformName$
-                localRotation = #$../../../PLUME[Hypergolic-Lower]/localRotation[0]$,$../../../PLUME[Hypergolic-Lower]/localRotation[1]$,$../../../PLUME[Hypergolic-Lower]/localRotation[2]$
-                localPosition = #$../../../PLUME[Hypergolic-Lower]/plumePosition[0]$,$../../../PLUME[Hypergolic-Lower]/plumePosition[1]$,$../../../PLUME[Hypergolic-Lower]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Hypergolic-Lower]/plumeScale$
-                energy        = #$../../../PLUME[Hypergolic-Lower]/energy$
-                speed         = #$../../../PLUME[Hypergolic-Lower]/speed$
-                emissionMult  = #$../../../PLUME[Hypergolic-Lower]/emissionMult$
-                //
-                name = plume
-                modelName = RealPlume/Ferram_FX/hypergolicexhaust
-                fixedEmissions = false
-                sizeClamp = 50
-                randConeEmit
-                {
-                  density = 1.0 0
-                  density = 0.5 0.3
-                  density = 0.25 0.9
-                  density = 0.06 0.9
-                  density = 0 1.4
-                }
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 2
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 1
-                  density = 0.8 3
-                  density = 0.46 4
-                  density = 0.2 10
-                  density = 0.1 5
-                  density = 0.0 4
-                }
-                linGrow
-                {
-                  density = 1.0 -0.2
-                  density = 0.8 0
-                  density = 0.46 1
-                  density = 0.2 7
-                  density = 0.05 12
-                  density = 0.0 14
-                }
-                speed
-                {
-                  density = 1.0 1
-                  density = 0.46 1.5
-                  density = 0.2 1.5
-                  density = 0.05 1.3
-                  density = 0.0 1.2
-                }
-                xyForce
-                {
-                  density = 1 0.65
-                  density = 0.5 0.85
-                  density = 0.25 0.9
-                  density = 0.06 0.95
-                  density = 0 1
-                }
-                zForce
-                {
-                  density = 1 1
-                  density = 0.2 1.02
-                  density = 0 1.033
-                }
-                emission
-                {
-                  density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1
-                  density = 0.05 1
-                  density = 0.0 1
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 1
-                  density = 0.3 1
-                  density = 0.2 1
-                  density = 0.05 0.7
-                  density = 0.0 0.3
-                }
-                size
-                {
-                  density = 1.0 0.85
-                  density = 0.8 0.85
-                  density = 0.2 0.75
-                  density = 0.0 0.75
-                }
-            }
-            AUDIO
-            {
-                channel = Ship
-                clip = RealPlume/KW_Sounds/sound_altloop2
-                volume = 0.0 0.0
-                volume = #$../../../PLUME[Hypergolic-Lower]/plumeScale$
-                @volume,1 ^= :^:1.0 :
-                pitch = 0.0 1.0
-                pitch = 1.0 1.0
-                loop = true
-            }
-        }
-        		
-    }
+		%Hypergolic-Lower
+		{
+			MODEL_MULTI_SHURIKEN_PERSIST
+			{
+				//Get the inputs from the other config.
+				transformName = #$../../../PLUME[Hypergolic-Lower]/transformName$
+				localRotation = #$../../../PLUME[Hypergolic-Lower]/localRotation[0]$,$../../../PLUME[Hypergolic-Lower]/localRotation[1]$,$../../../PLUME[Hypergolic-Lower]/localRotation[2]$
+				localPosition = #$../../../PLUME[Hypergolic-Lower]/flarePosition[0]$,$../../../PLUME[Hypergolic-Lower]/flarePosition[1]$,$../../../PLUME[Hypergolic-Lower]/flarePosition[2]$
+				fixedScale	= #$../../../PLUME[Hypergolic-Lower]/flareScale$
+				//
+				name = flare
+				modelName = RealPlume/Ferram_FX/hypergolicflare
+				emission = 0.0 0
+				emission = 0.01 0.2
+				emission = 1.0 2
+				speed = 0.0 1
+				speed = 1.0 1
+				offset = 0
+				energy = 0.0 0.5
+				energy = 1.0 0.5
+				size = 0.0 0.4
+				size = 1.0 0.4
+				fixedEmissions = false
+				randomInitalVelocityOffsetMaxRadius = 0.2
+				linGrow
+				{
+				  power = 1 15
+				  power = 0 15
+				}
+			}
+			MODEL_MULTI_SHURIKEN_PERSIST
+			{
+				//Get the inputs from the other config.
+				transformName = #$../../../PLUME[Hypergolic-Lower]/transformName$
+				localRotation = #$../../../PLUME[Hypergolic-Lower]/localRotation[0]$,$../../../PLUME[Hypergolic-Lower]/localRotation[1]$,$../../../PLUME[Hypergolic-Lower]/localRotation[2]$
+				localPosition = #$../../../PLUME[Hypergolic-Lower]/plumePosition[0]$,$../../../PLUME[Hypergolic-Lower]/plumePosition[1]$,$../../../PLUME[Hypergolic-Lower]/plumePosition[2]$
+				fixedScale	= #$../../../PLUME[Hypergolic-Lower]/plumeScale$
+				energy		= #$../../../PLUME[Hypergolic-Lower]/energy$
+				speed		 = #$../../../PLUME[Hypergolic-Lower]/speed$
+				emissionMult  = #$../../../PLUME[Hypergolic-Lower]/emissionMult$
+				//
+				name = plume
+				modelName = RealPlume/Ferram_FX/hypergolicexhaust
+				fixedEmissions = false
+				sizeClamp = 50
+				randConeEmit
+				{
+				  density = 1.0 0
+				  density = 0.5 0.3
+				  density = 0.25 0.9
+				  density = 0.06 0.9
+				  density = 0 1.4
+				}
+				logGrow
+				{
+				  density = 1.0 2
+				  density = 0.1 2
+				  density = 0.0 2
+				}
+				logGrowScale
+				{
+				  density = 1.0 1
+				  density = 0.8 3
+				  density = 0.46 4
+				  density = 0.2 10
+				  density = 0.1 5
+				  density = 0.0 4
+				}
+				linGrow
+				{
+				  density = 1.0 -0.2
+				  density = 0.8 0
+				  density = 0.46 1
+				  density = 0.2 7
+				  density = 0.05 12
+				  density = 0.0 14
+				}
+				speed
+				{
+				  density = 1.0 1
+				  density = 0.46 1.5
+				  density = 0.2 1.5
+				  density = 0.05 1.3
+				  density = 0.0 1.2
+				}
+				xyForce
+				{
+				  density = 1 0.65
+				  density = 0.5 0.85
+				  density = 0.25 0.9
+				  density = 0.06 0.95
+				  density = 0 1
+				}
+				zForce
+				{
+				  density = 1 1
+				  density = 0.2 1.02
+				  density = 0 1.033
+				}
+				emission
+				{
+				  density = 1.0 2
+				  density = 0.8 1.2
+				  density = 0.2 1
+				  density = 0.1 1
+				  density = 0.05 1
+				  density = 0.0 1
+				  power = 1 1
+				  power = 0.01 0.2
+				  power = 0 0
+				}
+				energy
+				{
+				  density = 1.0 1
+				  density = 0.3 1
+				  density = 0.2 1
+				  density = 0.05 0.7
+				  density = 0.0 0.3
+				}
+				size
+				{
+				  density = 1.0 0.85
+				  density = 0.8 0.85
+				  density = 0.2 0.75
+				  density = 0.0 0.75
+				}
+			}
+			AUDIO
+			{
+				channel = Ship
+				clip = RealPlume/KW_Sounds/sound_altloop2
+				volume = 0.0 0.0
+				volume = #$../../../PLUME[Hypergolic-Lower]/plumeScale$
+				@volume,1 ^= :^:1.0 :
+				pitch = 0.0 1.0
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+				
+	}
 }

--- a/GameData/JetSoundsUpdated/Patches/SXTMiniJet.cfg
+++ b/GameData/JetSoundsUpdated/Patches/SXTMiniJet.cfg
@@ -65,7 +65,7 @@
 	}
 }
 
-@PART[SXTMiniJet]:NEEDS[RealPlume]:FOR[zzJetSounds]
+@PART[SXTMiniJet]:AFTER[zzRealPlume]
 {
     %EFFECTS
     {

--- a/GameData/JetSoundsUpdated/Patches/Wheesley.cfg
+++ b/GameData/JetSoundsUpdated/Patches/Wheesley.cfg
@@ -2,7 +2,7 @@
 //---Wheesley config by JeanTheDragon and PlumeParty/PlumeParty/RealPlume compatibility by theonegalen
 
  
-@PART[JetEngine]:NEEDS[!RealPlume,!PlumeParty]
+@PART[JetEngine]:NEEDS[!RealPlume]
 {
 	@EFFECTS
 	{		
@@ -61,14 +61,7 @@
 				loop = false
 			}
 		}
-	}
-}
-
-@PART[JetEngine]:NEEDS[AirplanePlus,!RealPlume,!PlumeParty]
-{
-	@EFFECTS
-	{		
-		@flameout
+		%flameout
 		{
 			!AUDIO {}
 			AUDIO
@@ -83,152 +76,17 @@
 	}
 }
 
-@PART[JetEngine]:NEEDS[AirplanePlus]:AFTER[PlumeParty]
+@PART[JetEngine]:AFTER[zzRealPlume]
 {
-	@EFFECTS
-	{		
-		@flameout
+	%EFFECTS
+	{
+		%Turbofan-Spool
 		{
-			!AUDIO {}
+			!AUDIO,* {}
 			AUDIO
 			{
+				name = sndjet1
 				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-	}
-}
-
-@PART[JetEngine]:NEEDS[RealPlume]:FOR[zzJetSounds]
-{
-    %EFFECTS
-    {
-        %Turbofan
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                
-                transformName = #$../../../PLUME[Turbofan]/transformName$
-                localRotation = #$../../../PLUME[Turbofan]/localRotation[0]$,$../../../PLUME[Turbofan]/localRotation[1]$,$../../../PLUME[Turbofan]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbofan]/plumePosition[0]$,$../../../PLUME[Turbofan]/plumePosition[1]$,$../../../PLUME[Turbofan]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbofan]/plumeScale$
-                energy        = #$../../../PLUME[Turbofan]/energy$
-                speed         = #$../../../PLUME[Turbofan]/speed$
-                emissionMult  = #$../../../PLUME[Turbofan]/emissionMult$
-                //
-                name = plume
-                modelName = RealPlume/MP_Nazari_FX/flamejet3
-                speed = 0.0 1.45
-                speed = 1.0 1.45
-                energy = 0.0 0.05
-                energy = 0.5 0.4
-                energy = 1.0 0.7
-                fixedEmissions = false
-                randConeEmit
-                {
-                  density = 1 0
-                  density = 0 0.5
-                }
-                energy
-                {
-                  density = 1 0.5
-                  density = 0 0.2
-                }
-                emission
-                {
-                  density = 1 1
-                  density = 0 0.5
-                  power = 0.0 0.0
-                  power = 0.42 0.0
-                  power = 0.54 1.55
-                  power = 1.0 1.78
-                }
-                speed
-                {
-                  density = 1 1.2
-                  density = 0 1.5
-                }
-            }
-        }
-        %Turbofan-Spool
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Turbofan]/transformName$
-                fixedScale    = #$../../../PLUME[Turbofan]/smokeScale$
-                localPosition = #$../../../PLUME[Turbofan]/smokePosition[0]$,$../../../PLUME[Turbofan]/smokePosition[1]$,$../../../PLUME[Turbofan]/smokePosition[2]$
-                //
-                name = smoke
-                modelName = RealPlume/MP_Nazari_FX/smokejet
-                fixedEmissions = false
-                sizeClamp = 50
-                randomInitalVelocityOffsetMaxRadius = 0.5
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 20
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 0.0
-                  density = 0.8 2
-                  density = 0.46 3
-                  density = 0.2 3
-                  density = 0.1 4
-                  density = 0.0 5
-                }
-                linGrow
-                {
-                  density = 1.0 0
-                  density = 0.46 0.0
-                  density = 0.2 0
-                  density = 0.05 30
-                  density = 0.0 40
-                }
-                grow
-                {
-                  density = 1 0
-                  density = 0.2 0
-                  density = 0.1 4
-                  density = 0 9
-                }
-                speed
-                {
-                  density = 1.0 1.7
-                  density = 0.46 1.7
-                  density = 0.2 1.5
-                  density = 0.05 1.5
-                  density = 0.0 1.5
-                }
-                emission
-                {
-                   density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
-                  density = 0.0 0
-                }
-            }
-            AUDIO
-            {
-                name = sndjet1
-                channel = Ship
 				clip = JetSoundsUpdated/Sounds/CFM56_Running_Low
 				volume = 0.0 0.0
 				volume = 0.05 0.35
@@ -237,11 +95,11 @@
 				pitch = 0.05 0.8
 				pitch = 1.0 1.5
 				loop = true
-            }
-            AUDIO
-            {
-                name = sndjet2
-                channel = Ship
+			}
+			AUDIO
+			{
+				name = sndjet2
+				channel = Ship
 				clip = JetSoundsUpdated/Sounds/CFM56_Running_High
 				volume = 0.0 0.0
 				volume = 0.05 0.2
@@ -249,10 +107,11 @@
 				pitch = 0.0 1.2
 				pitch = 1.0 2.0
 				loop = true
-            }
-        }
-		engage
+			}
+		}
+		%engage
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -263,8 +122,9 @@
 				loop = false
 			}
 		}
-		disengage
+		%disengage
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -274,22 +134,5 @@
 				loop = false
 			}
 		}
-		flameout
-		{
-			PREFAB_PARTICLE
-			{
-				prefabName = fx_exhaustSparks_flameout_2
-				transformName = smokePoint
-				oneShot = true
-			}
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-    }
+	}
 }

--- a/GameData/JetSoundsUpdated/Patches/Whiplash.cfg
+++ b/GameData/JetSoundsUpdated/Patches/Whiplash.cfg
@@ -63,14 +63,7 @@
 				loop = false
 			}
 		}
-	}
-}
-
-@PART[turboFanEngine]:NEEDS[AirplanePlus,!RealPlume,!PlumeParty]
-{
-	@EFFECTS
-	{		
-		@flameout
+		%flameout
 		{
 			!AUDIO {}
 			AUDIO
@@ -85,193 +78,13 @@
 	}
 }
 
-@PART[turboFanEngine]:NEEDS[AirplanePlus]:AFTER[PlumeParty]
+@PART[turboFanEngine]:AFTER[zzRealPlume]
 {
-	@EFFECTS
-	{		
-		@flameout
+	%EFFECTS
+	{
+		%Turbojet-Spool
 		{
-			!AUDIO {}
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-	}
-}
-
-@PART[turboFanEngine]:NEEDS[RealPlume]:FOR[zzJetSounds]
-{
-    %EFFECTS
-    {
-        %Turbojet
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get configs from the PLUME node.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbojet]/flarePosition[0]$,$../../../PLUME[Turbojet]/flarePosition[1]$,$../../../PLUME[Turbojet]/flarePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbojet]/flareScale$
-                energy        = #$../../../PLUME[Turbojet]/energy$
-                speed         = #$../../../PLUME[Turbojet]/speed$
-                emissionMult  = #$../../../PLUME[Turbojet]/emissionMult$
-                //
-                name = flare
-                modelName = RealPlume/MP_Nazari_FX/flamejet3
-                emission = 0.0 0.0
-                emission = 0.42 0.0
-                emission = 0.54 1.55
-                emission = 1.0 1.78
-                speed = 0.0 1.45
-                speed = 1.0 1.45
-                energy = 0.0 0.05
-                energy = 0.5 0.77
-                energy = 1.0 0.99
-                fixedEmissions = false
-				emission
-				{
-				  density = 1 1
-				  density = 0.2 0.7
-				  density = 0.0 0.3
-				  power = 0.0 0.0
-				  power = 0.42 0.0
-				  power = 0.54 1.55
-				  power = 1.0 1.78
-				}
-				energy
-				{
-				  density = 1 1
-				  density = 0.2 0.7
-				  density = 0.0 0.3
-				}
-            }
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get configs from the PLUME node.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                localRotation = #$../../../PLUME[Turbojet]/localRotation[0]$,$../../../PLUME[Turbojet]/localRotation[1]$,$../../../PLUME[Turbojet]/localRotation[2]$
-                localPosition = #$../../../PLUME[Turbojet]/plumePosition[0]$,$../../../PLUME[Turbojet]/plumePosition[1]$,$../../../PLUME[Turbojet]/plumePosition[2]$
-                fixedScale    = #$../../../PLUME[Turbojet]/plumeScale$
-                energy        = #$../../../PLUME[Turbojet]/energy$
-                speed         = #$../../../PLUME[Turbojet]/speed$
-                //
-                name = afterburner
-                modelName = RealPlume/MP_Nazari_FX/methanolflame
-                emission = 0.0 0.0
-                emission = 0.42 0.0
-                emission = 0.74 0.0
-                emission = 0.84 1.0
-                emission = 1.0 1.78
-                speed = 0.0 1.3
-                speed = 1.0 1.3
-                energy = 0.0 0.00
-                energy = 0.7 0.05
-                energy = 1.0 0.99
-                fixedEmissions = false
-                offset = 1.5
-                size = 0.7
-                logGrow
-                {
-                  density = 1 0
-                  density = 0.3 2
-                  density = 0.0 20
-                }
-                emission
-                {
-                  density = 1 2
-                  density = 0.2 1.5
-                  density = 0.0 0.2
-                  power = 0.0 0.0
-                  power = 0.42 0.0
-                  power = 0.74 0.0
-                  power = 0.84 1.0
-                  power = 1.0 1.78
-                }
-                energy
-                {
-                  density = 1 1
-                  density = 0.2 0.7
-                  density = 0.0 0.2
-                }
-            }
-        }
-        %Turbojet-Spool
-        {
-            MODEL_MULTI_SHURIKEN_PERSIST
-            {
-                //Get the inputs from the other config.
-                transformName = #$../../../PLUME[Turbojet]/transformName$
-                fixedScale    = #$../../../PLUME[Turbojet]/smokeScale$
-                localPosition = #$../../../PLUME[Turbojet]/smokePosition[0]$,$../../../PLUME[Turbojet]/smokePosition[1]$,$../../../PLUME[Turbojet]/smokePosition[2]$
-                //
-                name = smoke
-                modelName = RealPlume/MP_Nazari_FX/smokejet
-                fixedEmissions = false
-                sizeClamp = 50
-                randomInitalVelocityOffsetMaxRadius = 0.5
-                logGrow
-                {
-                  density = 1.0 2
-                  density = 0.1 20
-                  density = 0.0 2
-                }
-                logGrowScale
-                {
-                  density = 1.0 0.0
-                  density = 0.8 2
-                  density = 0.46 3
-                  density = 0.2 3
-                  density = 0.1 4
-                  density = 0.0 5
-                }
-                linGrow
-                {
-                  density = 1.0 0
-                  density = 0.46 0.0
-                  density = 0.2 0
-                  density = 0.05 30
-                  density = 0.0 40
-                }
-                grow
-                {
-                  density = 1 0
-                  density = 0.2 0
-                  density = 0.1 4
-                  density = 0 9
-                }
-                speed
-                {
-                  density = 1.0 1.7
-                  density = 0.46 1.7
-                  density = 0.2 1.5
-                  density = 0.05 1.5
-                  density = 0.0 1.5
-                }
-                emission
-                {
-                  density = 1.0 2
-                  density = 0.8 1.2
-                  density = 0.2 1
-                  density = 0.1 1.2
-                  density = 0.05 1.5
-                  density = 0.0 1.7
-                  power = 1 1
-                  power = 0.01 0.2
-                  power = 0 0
-                }
-                energy
-                {
-                  density = 1.0 2
-                  density = 0.3 2
-                  density = 0.05 1
-                  density = 0.0 0
-                }
-            }
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -298,9 +111,10 @@
 				pitch = 1.0 1.5
 				loop = true
 			}
-        }
-		engage
+		}
+		%engage
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -310,8 +124,9 @@
 				loop = false
 			}
 		}
-		disengage
+		%disengage
 		{
+			!AUDIO,* {}
 			AUDIO
 			{
 				channel = Ship
@@ -321,22 +136,5 @@
 				loop = false
 			}
 		}
-		flameout
-		{
-			PREFAB_PARTICLE
-			{
-				prefabName = fx_exhaustSparks_flameout_2
-				transformName = smokePoint
-				oneShot = true
-			}
-			AUDIO
-			{
-				channel = Ship
-				clip = sound_explosion_low
-				volume = 1.0
-				pitch = 2.0
-				loop = false
-			}
-		}
-    }
+	}
 }


### PR DESCRIPTION
* declare `:AFTER[zzRealPlume]` as suggested by Zorg, delete combination NEEDS + FOR pass. NEEDS is apparently ignored when FOR is given so this combination does not work as you expect.
* delete AirplanePlus NEEDS except where assets from AirplanePlus are actually used.
* delete PlumeParty NEEDS as PlumeParty already avoids adding audio to stock jet engines.